### PR TITLE
changing to textContent instead of innerText

### DIFF
--- a/src/app/public/src/modules/code-block/code-block.component.ts
+++ b/src/app/public/src/modules/code-block/code-block.component.ts
@@ -67,7 +67,7 @@ export class StacheCodeBlockComponent implements AfterViewInit {
     if (this.code) {
       code = this.code;
     } else {
-      code = this.codeTemplateRef.nativeElement.innerText;
+      code = this.codeTemplateRef.nativeElement.textContent;
     }
 
     code = this.formatCode(code);


### PR DESCRIPTION
innerText was stripping out the new lines in IE, causing `code-blocks` to render as one long string.  Using textContent preserves the `\n` to allow IE11 to render them properly.  

http://kellegous.com/j/2013/02/27/innertext-vs-textcontent/

Resolves: https://github.com/blackbaud/stache2/issues/421