### PR TITLE
Update Browser Page Title functionality

### DIFF
--- a/src/app/public/src/modules/wrapper/title.service.ts
+++ b/src/app/public/src/modules/wrapper/title.service.ts
@@ -14,7 +14,7 @@ export class StacheTitleService {
 
     if (parts && parts.length > 0) {
       parts.push(windowTitle);
-      let validParts = parts.filter(part => part !== undefined);
+      let validParts = parts.filter(part => part);
       windowTitle = validParts.join(' - ');
     }
 

--- a/src/app/public/src/modules/wrapper/wrapper.component.spec.ts
+++ b/src/app/public/src/modules/wrapper/wrapper.component.spec.ts
@@ -37,6 +37,7 @@ describe('StacheWrapperComponent', () => {
   let mockWindowService: any;
   let mockAnchorService: any;
   let mockOmnibarService: any;
+  let mockTextContent: string = '';
 
   class MockActivatedRoute {
     public fragment: Observable<string> = Observable.of('test-route');
@@ -112,6 +113,7 @@ describe('StacheWrapperComponent', () => {
         }),
         querySelector: jasmine.createSpy('querySelector').and.callFake(function(selector: string) {
           return {
+            textContent: mockTextContent,
             classList: {
               add(cssClass: string) { }
             },
@@ -291,6 +293,25 @@ describe('StacheWrapperComponent', () => {
     component.pageTitle = 'Page Title';
     fixture.detectChanges();
     expect(mockTitleService.setTitle).toHaveBeenCalledWith('Page Title');
+  });
+
+  it('should set the nav title', () => {
+    component.pageTitle = 'Nav Title';
+    fixture.detectChanges();
+    expect(mockTitleService.setTitle).toHaveBeenCalledWith('Nav Title');
+  });
+
+  it('should set the Tutorial Header title', () => {
+    mockTextContent = 'Tutorial Header Title';
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(mockTitleService.setTitle).toHaveBeenCalledWith('Tutorial Header Title');
+    mockTextContent = '';
+  });
+
+  it('should not set the Tutorial Header title', () => {
+    fixture.detectChanges();
+    expect(mockTitleService.setTitle).not.toHaveBeenCalledWith('Tutorial Header Title');
   });
 
   it('should set the jsonData property on init', () => {

--- a/src/app/public/src/modules/wrapper/wrapper.component.ts
+++ b/src/app/public/src/modules/wrapper/wrapper.component.ts
@@ -8,11 +8,9 @@ import {
   ChangeDetectorRef
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-
 import { Subscription } from 'rxjs';
-
 import { StacheTitleService } from './title.service';
-import { StacheConfigService, StacheJsonDataService, StacheOmnibarAdapterService } from '../shared';
+import { StacheConfigService, StacheJsonDataService, StacheOmnibarAdapterService, StacheWindowRef } from '../shared';
 import { StacheNavLink, StacheNavService } from '../nav';
 import { StachePageAnchorService } from '../page-anchor/page-anchor.service';
 
@@ -54,6 +52,7 @@ export class StacheWrapperComponent implements OnInit, OnDestroy, AfterViewInit 
   @Input()
   public showBackToTop: boolean = true;
 
+  public tutorialHeader: string;
   public jsonData: any;
   public inPageRoutes: StacheNavLink[] = [];
   private pageAnchorSubscription: Subscription;
@@ -66,22 +65,31 @@ export class StacheWrapperComponent implements OnInit, OnDestroy, AfterViewInit 
     private navService: StacheNavService,
     private anchorService: StachePageAnchorService,
     private cdr: ChangeDetectorRef,
+    private windowRef: StacheWindowRef,
     private omnibarService: StacheOmnibarAdapterService) { }
 
   public ngOnInit(): void {
     this.omnibarService.checkForOmnibar();
-    this.titleService.setTitle(this.windowTitle || this.pageTitle);
     this.jsonData = this.dataService.getAll();
     this.registerPageAnchors();
   }
 
   public ngAfterViewInit() {
+    this.checkForTutorialHeader();
+    this.titleService.setTitle(this.windowTitle || this.pageTitle || this.navTitle || this.tutorialHeader);
     this.checkRouteHash();
     this.cdr.detectChanges();
   }
 
   public ngOnDestroy(): void {
     this.destroyPageAnchorSubscription();
+  }
+
+  private checkForTutorialHeader() {
+    const currentTutorialHeader = this.windowRef.nativeWindow.document.querySelector(`.stache-tutorial-heading`);
+    if (currentTutorialHeader && currentTutorialHeader.textContent) {
+      this.tutorialHeader = currentTutorialHeader.textContent.trim();
+    }
   }
 
   private registerPageAnchors(): void {


### PR DESCRIPTION
Include navTitle and tutorialHeader as options for browser page title when pageTitle stache attribute is absent