### PR TITLE
fixed a bug with internal navigation

### DIFF
--- a/src/app/public/src/modules/nav/nav.service.spec.ts
+++ b/src/app/public/src/modules/nav/nav.service.spec.ts
@@ -109,6 +109,16 @@ describe('StacheNavService', () => {
     expect(elementScrollCalled).toBe(true);
   });
 
+  it('should navigate to an internal url if the path provided is an array of paths', () => {
+    navService.navigate({path: ['/internal'], fragment: 'element-id'});
+    expect(elementScrollCalled).toBe(true);
+  });
+
+  it('should not navigate to an internal url if the path provided is an array of paths that do not match currentUrl', () => {
+    navService.navigate({path: ['/internal', 'not-in-page'], fragment: 'element-id'});
+    expect(elementScrollCalled).toBe(false);
+  });
+
   it('should navigate to an internal url',
    () => {
     navService.navigate({path: 'internal', fragment: 'does-not-exist'});

--- a/src/app/public/src/modules/nav/nav.service.ts
+++ b/src/app/public/src/modules/nav/nav.service.ts
@@ -11,7 +11,7 @@ export class StacheNavService {
 
   public navigate(route: any): void {
     let extras: any = { queryParamsHandling: 'merge'};
-    const currentPath = this.router.url.split('?')[0].split('#')[0].substring(1);
+    const currentPath = this.router.url.split('?')[0].split('#')[0];
 
     if (this.isExternal(route)) {
       this.windowRef.nativeWindow.location.href = route.path;
@@ -19,11 +19,10 @@ export class StacheNavService {
     }
 
     if (route.fragment) {
-      if (route.path === currentPath || route.path === '.') {
+      if (this.isCurrentRoute(route.path, currentPath)) {
         this.navigateInPage(route.fragment);
         return;
       }
-
       extras.fragment = route.fragment;
     }
 
@@ -32,6 +31,16 @@ export class StacheNavService {
     } else {
       this.router.navigate([route.path], extras);
     }
+  }
+
+  private isCurrentRoute(routePath: string | string[], currentPath: string): boolean {
+   let path = routePath;
+
+   if (Array.isArray(path)) {
+    path = path.join('/');
+   }
+
+   return (path === '.' || currentPath.replace(/^\//, '') === path.replace(/^\//, ''));
   }
 
   private navigateInPage(fragment: string): void {


### PR DESCRIPTION
Resolves a bug introduced with https://github.com/blackbaud/stache2/pull/452 

If the route.path was an array, it would never match the `currentPath` 