### PR TITLE
Open edit page in new tab/window

### DIFF
--- a/src/app/public/src/modules/edit-button/edit-button.component.html
+++ b/src/app/public/src/modules/edit-button/edit-button.component.html
@@ -1,5 +1,5 @@
 <div class="stache-edit-button" *ngIf="url">
-  <a class="stache-btn-edit" [href]="url">
+  <a class="stache-btn-edit" [href]="url" target="_blank">
     <i class="fa fa-edit" aria-hidden="true"></i>
     {{ editButtonText }}
   </a>


### PR DESCRIPTION
Include `target="_blank"`  in the `edit-button` component's anchor tag to open the edit page in a new window/tab.

This is more convenient to end users - they can view the content and code simultaneously without having to move back/forward between pages, or having to remember to "open in new tab".

#533 - associated issue