### PR TITLE
allow long words to wrap

### DIFF
--- a/src/app/public/src/modules/code/code.component.scss
+++ b/src/app/public/src/modules/code/code.component.scss
@@ -1,6 +1,7 @@
 @import '../../styles/_variables';
 
 .stache-code {
+  overflow-wrap: break-word;
   font-family: 'Menlo', 'Monaco', 'Consolas', 'Courier New', monospace;
   font-size: 90%;
   color: $stache-background-color-danger-dark;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38473653/51415192-fc86e080-1b42-11e9-8e21-d6051930c9b6.png)
Fixes issue where long words will leave parent div without wrapping. 