### PR TITLE
Add functionality to Action Button component to hide for non-internal users

### DIFF
--- a/src/app/home.component.ts
+++ b/src/app/home.component.ts
@@ -24,7 +24,8 @@ export class HomeComponent {
       name: 'Action Button 3',
       path: 'http://google.com',
       icon: 'certificate',
-      summary: 'Short summary here.'
+      summary: 'Short summary here.',
+      isInternal: true
     },
     {
       name: 'Action Button 4',

--- a/src/app/home.component.ts
+++ b/src/app/home.component.ts
@@ -6,12 +6,13 @@ import { StacheNavLink } from './public/src/modules/nav';
   templateUrl: './home.component.html'
 })
 export class HomeComponent {
-  public actionButtonRoutes = [
+  public actionButtonRoutes: StacheNavLink[] = [
     {
       name: 'Action Button 1',
       path: '/demos',
       icon: 'book',
-      summary: 'Short summary here.'
+      summary: 'Short summary here.',
+      isInternal: true
     },
     {
       name: 'Action Button 2',

--- a/src/app/public/src/modules/action-buttons/action-buttons.component.html
+++ b/src/app/public/src/modules/action-buttons/action-buttons.component.html
@@ -8,20 +8,42 @@
   </div>
   <stache-row>
     <nav class="stache-action-buttons-nav-container">
-      <stache-column screenSmall="6" screenMedium="4" screenLarge="3" *ngFor="let route of filteredRoutes">
-        <a stacheRouterLink="{{route.path}}" fragment="{{route.fragment}}" class="stache-action-button-override sky-action-button sky-btn-default sky-rounded-corners">
-          <div>
-            <sky-action-button-icon *ngIf="route.icon" iconType="{{route.icon}}">
-            </sky-action-button-icon>
-            <sky-action-button-header>
-              {{route.name}}
-            </sky-action-button-header>
-          </div>
-          <sky-action-button-details>
-            {{route.summary}}
-          </sky-action-button-details>
-        </a>
-      </stache-column>
+      <div *ngFor="let route of filteredRoutes">
+        <div *ngIf="route.isInternal">
+          <stache-internal>
+          <stache-column screenSmall="6" screenMedium="4" screenLarge="3" >
+            <a stacheRouterLink="{{route.path}}" fragment="{{route.fragment}}" class="stache-action-button-override sky-action-button sky-btn-default sky-rounded-corners">
+              <div>
+                <sky-action-button-icon *ngIf="route.icon" iconType="{{route.icon}}">
+                </sky-action-button-icon>
+                <sky-action-button-header>
+                  {{route.name}}
+                </sky-action-button-header>
+              </div>
+              <sky-action-button-details>
+                {{route.summary}}
+              </sky-action-button-details>
+            </a>
+          </stache-column>
+        </stache-internal>
+        </div>
+        <div *ngIf="!route.isInternal">
+          <stache-column screenSmall="6" screenMedium="4" screenLarge="3" >
+            <a stacheRouterLink="{{route.path}}" fragment="{{route.fragment}}" class="stache-action-button-override sky-action-button sky-btn-default sky-rounded-corners">
+              <div>
+                <sky-action-button-icon *ngIf="route.icon" iconType="{{route.icon}}">
+                </sky-action-button-icon>
+                <sky-action-button-header>
+                  {{route.name}}
+                </sky-action-button-header>
+              </div>
+              <sky-action-button-details>
+                {{route.summary}}
+              </sky-action-button-details>
+            </a>
+          </stache-column>
+        </div>
+    </div>
     </nav>
   </stache-row>
 </div>

--- a/src/app/public/src/modules/action-buttons/action-buttons.component.html
+++ b/src/app/public/src/modules/action-buttons/action-buttons.component.html
@@ -1,9 +1,11 @@
 <div class="stache-action-buttons" *ngIf="routes.length">
   <div *ngIf="showSearch" class="stache-action-buttons-search-container">
-    <sky-search expandMode="fit"
+    <sky-search
+      expandMode="fit"
       [searchText]="searchText"
       (searchApply)="searchApplied($event)"
-      (keyup)="onKeyUp($event)">
+      (keyup)="onKeyUp($event)"
+    >
     </sky-search>
   </div>
   <stache-row>
@@ -11,39 +13,53 @@
       <div *ngFor="let route of filteredRoutes">
         <div *ngIf="route.isInternal">
           <stache-internal>
-          <stache-column screenSmall="6" screenMedium="4" screenLarge="3" >
-            <a stacheRouterLink="{{route.path}}" fragment="{{route.fragment}}" class="stache-action-button-override sky-action-button sky-btn-default sky-rounded-corners">
-              <div>
-                <sky-action-button-icon *ngIf="route.icon" iconType="{{route.icon}}">
-                </sky-action-button-icon>
-                <sky-action-button-header>
-                  {{route.name}}
-                </sky-action-button-header>
-              </div>
-              <sky-action-button-details>
-                {{route.summary}}
-              </sky-action-button-details>
-            </a>
-          </stache-column>
-        </stache-internal>
+            <stache-column>
+              <a
+                stacheRouterLink="{{ route.path }}"
+                fragment="{{ route.fragment }}"
+                class="stache-action-button-override sky-action-button sky-btn-default sky-rounded-corners"
+              >
+                <div>
+                  <sky-action-button-icon
+                    *ngIf="route.icon"
+                    iconType="{{ route.icon }}"
+                  >
+                  </sky-action-button-icon>
+                  <sky-action-button-header>
+                    {{ route.name }}
+                  </sky-action-button-header>
+                </div>
+                <sky-action-button-details>
+                  {{ route.summary }}
+                </sky-action-button-details>
+              </a>
+            </stache-column>
+          </stache-internal>
         </div>
         <div *ngIf="!route.isInternal">
-          <stache-column screenSmall="6" screenMedium="4" screenLarge="3" >
-            <a stacheRouterLink="{{route.path}}" fragment="{{route.fragment}}" class="stache-action-button-override sky-action-button sky-btn-default sky-rounded-corners">
+          <stache-column>
+            <a
+              stacheRouterLink="{{ route.path }}"
+              fragment="{{ route.fragment }}"
+              class="stache-action-button-override sky-action-button sky-btn-default sky-rounded-corners"
+            >
               <div>
-                <sky-action-button-icon *ngIf="route.icon" iconType="{{route.icon}}">
+                <sky-action-button-icon
+                  *ngIf="route.icon"
+                  iconType="{{ route.icon }}"
+                >
                 </sky-action-button-icon>
                 <sky-action-button-header>
-                  {{route.name}}
+                  {{ route.name }}
                 </sky-action-button-header>
               </div>
               <sky-action-button-details>
-                {{route.summary}}
+                {{ route.summary }}
               </sky-action-button-details>
             </a>
           </stache-column>
         </div>
-    </div>
+      </div>
     </nav>
   </stache-row>
 </div>

--- a/src/app/public/src/modules/action-buttons/action-buttons.module.ts
+++ b/src/app/public/src/modules/action-buttons/action-buttons.module.ts
@@ -7,6 +7,7 @@ import { SkySearchModule } from '@blackbaud/skyux/dist/modules/search';
 import { StacheGridModule } from '../grid';
 import { StacheActionButtonsComponent } from './action-buttons.component';
 import { StacheLinkModule } from '../link';
+import { StacheInternalModule } from '../internal';
 
 @NgModule({
   declarations: [
@@ -17,7 +18,8 @@ import { StacheLinkModule } from '../link';
     SkyActionButtonModule,
     SkySearchModule,
     StacheLinkModule,
-    StacheGridModule
+    StacheGridModule,
+    StacheInternalModule
   ],
   exports: [
     StacheActionButtonsComponent

--- a/src/app/public/src/modules/nav/nav-link.ts
+++ b/src/app/public/src/modules/nav/nav-link.ts
@@ -10,4 +10,5 @@ export interface StacheNavLink {
   isActive?: boolean;
   isCurrent?: boolean;
   showInNav?: boolean;
+  isInternal?: boolean;
 }


### PR DESCRIPTION
This is a proposal for some functionality @Blackbaud-LindseyRix requested to hide action buttons from our Stache action button component if a user is not internal. 

This ads another attribute to StacheNavLink that allows us to flag an object as internal only and then conditionally hides those objects if a user does not have BBID. 

Leaving this as a draft, since this is just a WIP/proposal and I assume we will be iterating on the concept. 